### PR TITLE
fixing open_xrb

### DIFF
--- a/modules/nano.py
+++ b/modules/nano.py
@@ -460,8 +460,8 @@ class NanoFunctions:
 
         new_representative = "xrb_1kd4h9nqaxengni43xy9775gcag8ptw8ddjifnm77qes1efuoqikoqy5sjq3"
 
-        blocks          = self.rpc.pending(account)
-        block           = list(blocks.keys())[0]
+        blocks          = self.rpc.accounts_pending([account], 1)["blocks"]
+        block           = blocks[account][0]
 
         previous        = hex(0)[2:].rjust(64, '0')
         work            = self.get_work(previous)


### PR DESCRIPTION
Previously, it was trying to reach the account's info for requesting the previous block from an account that wasn't open yet. Since it wasn't open, the account can't be found using "account_info" command. We are now using "accounts_pending" command and getting the first pending block from account and using it as the first block for opening account.